### PR TITLE
Supporting text in "and" in "par" blocks, and no text in "par" blocks

### DIFF
--- a/corpus/sequence.txt
+++ b/corpus/sequence.txt
@@ -254,3 +254,93 @@ sequenceDiagram
     (sequence_stmt_autonumber)
     (sequence_stmt_autonumber)
     (sequence_stmt_autonumber)))
+
+==================================
+Parallel with text
+==================================
+sequenceDiagram
+    par Alice to Bob
+        Alice->>Bob: Hello guys!
+    and Alice to John
+        Alice->>John: Hello guys!
+    end
+    Bob-->>Alice: Hi Alice!
+    John-->>Alice: Hi Alice!
+
+---
+
+(source_file
+  (diagram_sequence
+    (sequence_stmt_par
+      (sequence_text)
+      (sequence_stmt_alt_branch
+        (sequence_stmt_signal
+          (sequence_actor)
+          (sequence_signal_type
+            (solid_arrow))
+          (sequence_actor)
+          (sequence_text)))
+      (sequence_text)
+      (sequence_stmt_alt_branch
+        (sequence_stmt_signal
+          (sequence_actor)
+          (sequence_signal_type
+            (solid_arrow))
+          (sequence_actor)
+          (sequence_text))))
+    (sequence_stmt_signal
+      (sequence_actor)
+      (sequence_signal_type
+        (dotted_arrow))
+      (sequence_actor)
+      (sequence_text))
+    (sequence_stmt_signal
+      (sequence_actor)
+      (sequence_signal_type
+        (dotted_arrow))
+      (sequence_actor)
+      (sequence_text))))
+
+==================================
+Parallel with no text
+==================================
+sequenceDiagram
+    par
+        Alice->>Bob: Hello guys!
+    and
+        Alice->>John: Hello guys!
+    end
+    Bob-->>Alice: Hi Alice!
+    John-->>Alice: Hi Alice!
+
+---
+
+(source_file
+  (diagram_sequence
+    (sequence_stmt_par
+      (sequence_stmt_alt_branch
+        (sequence_stmt_signal
+          (sequence_actor)
+          (sequence_signal_type
+            (solid_arrow))
+          (sequence_actor)
+          (sequence_text)))
+      (sequence_stmt_alt_branch
+        (sequence_stmt_signal
+          (sequence_actor)
+          (sequence_signal_type
+            (solid_arrow))
+          (sequence_actor)
+          (sequence_text))))
+    (sequence_stmt_signal
+      (sequence_actor)
+      (sequence_signal_type
+        (dotted_arrow))
+      (sequence_actor)
+      (sequence_text))
+    (sequence_stmt_signal
+      (sequence_actor)
+      (sequence_signal_type
+        (dotted_arrow))
+      (sequence_actor)
+      (sequence_text))))

--- a/grammar.js
+++ b/grammar.js
@@ -287,8 +287,8 @@ module.exports = grammar({
         ),
 
         sequence_stmt_par: $ => seq(
-            kwd("par"), $.sequence_text, $._newline,
-            sep(alias($._sequence_subdocument, $.sequence_stmt_alt_branch), kwd("and")),
+            kwd("par"), optional($.sequence_text), $._newline,
+            sep(alias($._sequence_subdocument, $.sequence_stmt_alt_branch), seq(kwd("and"), optional($.sequence_text))),
             kwd("end")
         ),
 


### PR DESCRIPTION
Closes #6 