### PR TITLE
Add github action to build wasm files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Create release
+
+on:
+  push:
+    tags: ["*"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  release:
+    uses: tree-sitter/workflows/.github/workflows/release.yml@main

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,37 @@
+{
+  "metadata": {
+    "version": "0.0.1",
+    "license": "MIT",
+    "authors": [
+      {
+        "name": "monaqa"
+      }
+    ],
+    "description": "Mermaid grammar for tree-sitter",
+    "links": {
+      "repository": "https://github.com/monaqa/tree-sitter-mermaid"
+    }
+  },
+  "grammars": [
+    {
+      "name": "mermaid",
+      "scope": "text.mermaid",
+      "path": ".",
+      "injection-regex": "^(mermaid|mmd)$",
+      "file-types": [
+        "mmd"
+      ],
+      "highlights": "queries/highlights.scm"
+    }
+  ],
+  "bindings": {
+    "c": true,
+    "go": false,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true,
+    "java": false,
+    "zig": false
+  }
+}


### PR DESCRIPTION
I added simple workflow which generates wasm file and stores it under releases:

https://github.com/ggodlewski/tree-sitter-mermaid/releases/tag/v0.0.1

All you need to do after merge is adding tag.

I'd appreciate if you can merge it and I don't have to maintain additional repo.